### PR TITLE
a few fixes & useability enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,12 +84,16 @@ function DNSResponse (req, res) {
 	var self = this;
 	self.begins = 0;
 	self.ends = 0;
+	self.header = res.header;
 
 	dnsTypes.forEach(function (type) {
 		var ltype = type.toLowerCase();
 
-		self[ltype] = function () {
-			res.answer.push(dns[type].apply(dns, arguments));
+		self[ltype] = function (rr) {
+			if (~['authority', 'additional', 'edns_options'].indexOf(rr && rr.type))
+				res[rr.type].push(dns[type].apply(dns, arguments));
+			else
+				res.answer.push(dns[type].apply(dns, arguments));
 			return this;
 		}
 	});

--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ function ExpressDNS (options) {
 		server.serve.apply(server, arguments);
 	};
 
+	DNS.close = function () {
+		server.close.apply(server, arguments);
+	};
+
 	server.on('request', function (req, res) {
 		var request = new DNSRequest(req, res);
 		var response = new DNSResponse(req, res);


### PR DESCRIPTION
line#10 - passed options to createServer to gain access to { type & reuseAddr }
    e.g. var server = require('dns-express')({ dgram_type: { type: 'udp6', reuseAddr: true } });
lines#27,29,41 - changed name matching logic to facilitate captures from the regex
    e.g. /^([\w]+).domain.com$/
    is available as req.match[1]
line#85 - added 'var' to ltype declaration to enable global use of 'use_strict'
line#89 - changed the response[<type>]() methods to return 'this' to allow method chaining
    e.g. res.a({<blah>}).end();
