### PR TITLE
changed ExpressDNS() to return the native-dns server, with the Usey methods added

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function ExpressDNS (options) {
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#Using_apply_in_monkey-patching
 	//var close = DNS.events.close.bind(DNS.events);
 	//DNS.events.close = function () {
-	//	return DNS.events.close.apply(DNS.events, arguments);
+	//	return close.apply(DNS.events, arguments);
 	//};
 
 	// receive requests from the native-dns server


### PR DESCRIPTION
Have ExpressDNS() return the native-dns server with the Usey method added.

API unchanged, but this exposes more native-dns functionality by default
